### PR TITLE
Stats are hitting production servers; not stat server

### DIFF
--- a/includes/modulesgarden/class.ModuleInformationClient.php
+++ b/includes/modulesgarden/class.ModuleInformationClient.php
@@ -35,10 +35,7 @@ if(!class_exists('ModuleInformationClient'))
         );
 
         //Server Location
-        //protected $url          =   'https://www.modulesgarden.com/manage/modules/addons/ModuleInformation/server.php';
-        protected $url          =   'https://www.liquidweb.com/manage/modules/addons/ModuleInformation/server.php';
-        //protected $url          =   'https://api.github.com/repos/santhoshbsuvarna/test1/releases/latest';
-
+        protected $url          =   'https://whmcspluginstats.liquidweb.com:443/liquidwebwhmcsplugin/Webservice.php';
 
         //This name will be send to modulesgarden.com
         protected $module       =   '';


### PR DESCRIPTION
Hey @santhoshsuvarna,

We were looking into some issues with stats and I believe this is the issue. The URL in the module info client is pointed to www which is not the correct server. Me and Mike looked this over and we believe that this URL should be correct!

Thanks!